### PR TITLE
Order Sorting improvement

### DIFF
--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -243,9 +243,27 @@ export abstract class BaseQueryRunner {
      * @param columns unordered table columns
      */
     protected getOrderedTableColumns(columns: TableColumn[]): TableColumn[] {
-        return columns.sort((a, b) => {
-            return a.order - b.order
-        })
+        //Find out the max order number defnied
+        //So we can assign to columns which does not have order number defined
+        const orders = columns.map(column => {
+            return column.order || null;
+        });
+        const max = Math.max(...orders);
+
+        //Now Sort columns, if order is undefined or null then push them in last
+        //We can do that by adding +1 to max and assigned to column for sorting
+        return columns.sort(function(a, b){
+        	if (a.order && b.order) {
+            	return a.order - b.order;
+            }
+            if (typeof b.order === 'undefined' || b.order === null) {
+            	b.order = ++max;
+            }
+        	if (typeof a.order === 'undefined' || a.order === null) {
+            	a.order = ++max;
+            }
+            return a.order - b.order;
+        });
     }
 
     /**


### PR DESCRIPTION
If the order is undefined or null then push them to last

Sample: 

```
const columns = [
    {name: 'test 1'}, // Order will be 21 after sorting
    {name: 'test 2'}, // Order will be 22 after sorting
    {name: 'test 3'}, // Order will be 23 after sorting
    {order: 15},
    {}, // Order will be 24 after sorting
    {order: 20},
    {order: -4},
    {order: -7},
    {}, // Order will be 25 after sorting
];
//console.log('columns', columns);

const orders = columns.map(column => {
    //console.log('column', column.order);
    //console.log('typeof column', typeof column.order);
    //console.log('column.order || -1', column.order || -1)
    return (typeof column.order === 'undefined' || column.order === null) ? -1 : column.order;
});

//console.log('orders', orders);
let max = Math.max(...orders);
//console.log('max', max);

columns.sort(function(a, b){
    if (a.order && b.order) {
        return a.order - b.order;
    }
    if (typeof b.order === 'undefined' || b.order === null) {
        b.order = ++max;
    }
    if (typeof a.order === 'undefined' || a.order === null) {
        a.order = ++max;
    }
    return a.order - b.order;
});

console.log('columns', columns);


/**
 * Result:
 * columns [
 *   { order: -7 },
 *   { order: -4 },
 *   { order: 15 },
 *   { order: 20 },
 *   { name: 'test 1', order: 21 },
 *   { name: 'test 2', order: 22 },
 *   { name: 'test 3', order: 23 },
 *   { order: 24 },
 *   { order: 25 }
 * ]
 */
```